### PR TITLE
Apply plugin in afterEvaluate to make compilation fail.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,50 @@
+# Compilation issue example
+
+When Apollo plugin is applied in afterEvaluate
+
+```kotlin
+project.afterEvaluate {
+    pluginManager.apply("com.apollographql.apollo3")
+    extensions.configure(com.apollographql.apollo3.gradle.api.ApolloExtension::class.java) {
+        service("MyService") {
+            packageName.set("com.example.rocketreserver")
+        }
+    }
+}
+```
+then compilation passes on `3.6.2` Apollo version, but fails with `3.7.1` version.
+
+
+When configuration is changed to
+
+```kotlin
+project.afterEvaluate {
+    pluginManager.apply("com.apollographql.apollo3")
+    extensions.configure(com.apollographql.apollo3.gradle.api.ApolloExtension::class.java) {
+        packageName.set("com.example.rocketreserver")
+    }
+}
+
+```
+then compilation passes on `3.6.2` and `3.7.1`
+
+
+When Apollo plugin is configured right away, but using `service`
+```kotlin
+plugins {
+    id("com.apollographql.apollo3").version("3.7.1")
+}
+
+apollo {
+    service("MyService") {
+        packageName.set("com.example.rocketreserver")
+    }
+}
+
+```
+
+then compilation passes on `3.6.2` and `3.7.1`.
+
 # Apollo Kotlin Tutorial
 
 This is the tutorial application for working with the [Apollo Kotlin SDK](https://github.com/apollographql/apollo-kotlin).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,13 @@ plugins {
     id("com.android.application")
     id("kotlin-android")
     id("androidx.navigation.safeargs.kotlin")
-    id("com.apollographql.apollo3").version("3.7.1")
+}
+
+buildscript {
+    dependencies {
+        classpath("com.apollographql.apollo3:apollo-gradle-plugin:3.7.1")
+//        classpath("com.apollographql.apollo3:apollo-gradle-plugin:3.6.2")
+    }
 }
 
 android {
@@ -52,6 +58,11 @@ dependencies {
     implementation("com.apollographql.apollo3:apollo-runtime")
 }
 
-apollo {
-    packageName.set("com.example.rocketreserver")
+project.afterEvaluate {
+    pluginManager.apply("com.apollographql.apollo3")
+    extensions.configure(com.apollographql.apollo3.gradle.api.ApolloExtension::class.java) {
+        service("MyService") {
+            packageName.set("com.example.rocketreserver")
+        }
+    }
 }


### PR DESCRIPTION
When Apollo plugin is applied in afterEvaluate

```kotlin
project.afterEvaluate {
    pluginManager.apply("com.apollographql.apollo3")
    extensions.configure(com.apollographql.apollo3.gradle.api.ApolloExtension::class.java) {
        service("MyService") {
            packageName.set("com.example.rocketreserver")
        }
    }
}
```
then compilation passes on `3.6.2` Apollo version, but fails with `3.7.1` version.


When configuration is changed to

```kotlin
project.afterEvaluate {
    pluginManager.apply("com.apollographql.apollo3")
    extensions.configure(com.apollographql.apollo3.gradle.api.ApolloExtension::class.java) {
        packageName.set("com.example.rocketreserver")
    }
}
```
then compilation passes on `3.6.2` and `3.7.1`


When Apollo plugin is configured right away, but using `service`
```kotlin
plugins {
    id("com.apollographql.apollo3").version("3.7.1")
}
apollo {
    service("MyService") {
        packageName.set("com.example.rocketreserver")
    }
}
```

then compilation passes on `3.6.2` and `3.7.1`.